### PR TITLE
compatible with different newline characters for getBundleInfo

### DIFF
--- a/src/device/hdc.ts
+++ b/src/device/hdc.ts
@@ -128,9 +128,9 @@ export class Hdc {
         if (output.length == 0) {
             return;
         }
-        let lines = output.split('\r\n');
+        let lines = output.split(/\r?\n/);
         try {
-            let info = JSON.parse(lines.slice(1).join('\r\n'));
+            let info = JSON.parse(lines.slice(1).join('\n'));
             return info;
         } catch (err) {
             return undefined;


### PR DESCRIPTION
解析BundleInfo时，兼容不同平台的换行符
windows是 \r\n, linux/maxos 是 \n